### PR TITLE
New tag for weekly announcements

### DIFF
--- a/content/posts/August-25-2024.mdx
+++ b/content/posts/August-25-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: Announcements for the Week of August 25-31
 date: "2024-08-23"
-tags: [announcements]
+tags: [announcement]
 ---
 
 **Meeting for Worship**

--- a/content/posts/September-1-2024.mdx
+++ b/content/posts/September-1-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: Announcements for the Week of September 1-7, 2024
 date: "2024-08-30"
-tags: [announcements]
+tags: [announcement]
 ---
 
 **Meeting for Worship**

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,7 +55,7 @@ export const query = graphql`
     allMdx(
       limit: 1
       sort: { frontmatter: { date: DESC } }
-      filter: { frontmatter: { tags: { in: "announcements" } } }
+      filter: { frontmatter: { tags: { in: "announcement" } } }
     ) {
       nodes {
         id

--- a/src/pages/news/index.js
+++ b/src/pages/news/index.js
@@ -26,7 +26,11 @@ export const query = graphql`
     allMdx(
       limit: 10
       sort: { frontmatter: { date: DESC } }
-      filter: { frontmatter: { tags: { nin: ["archived", "announcements"] } } }
+      filter: {
+        frontmatter: {
+          tags: { nin: ["archived", "announcements", "announcement"] }
+        }
+      }
     ) {
       nodes {
         id

--- a/src/shared/blogTags.js
+++ b/src/shared/blogTags.js
@@ -1,4 +1,5 @@
 export const BLOG_TAGS = {
+  announcement: "Announcements",
   announcements: "Announcements",
   arch: "ARCH",
   blog: "Blog Posts",


### PR DESCRIPTION
Very hacky and I don't know why it's needed.  But adding or editing posts that have the tag "announcements" makes them fall out of the list for the index page graphQL request.  